### PR TITLE
Filter results with getErrorResults()

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,10 +18,12 @@ function lint(file) {
     }
 
     function end() {
-        var report = cli.executeOnText(data, file);
+        var results = eslint.CLIEngine.getErrorResults(
+            cli.executeOnText(data, file).results
+        );
 
-        if (report.results.length) {
-            error(formatter(report.results));
+        if (results.length) {
+            error(formatter(results));
         }
 
         this.queue(data);


### PR DESCRIPTION
When I run this transform I get a blank link (empty string) for each file that has no errors. For me this PR gets me output for just files with errors.
