### PR TITLE
Only lint files that *end* with .js .jsx or .es6

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function lint(file, options) {
         this.queue(null);
     }
 
-    if (!/\.(js|jsx|es6)/.test(file) && file !== null) {
+    if (!/\.(js|jsx|es6)$/.test(file) && file !== null) {
         return through();
     }
 


### PR DESCRIPTION
Previously it would match all files that _contain_ .js, .jsx or .es6.
