### PR TITLE
suppress warnings about ignored files

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,17 @@ function lint(file, options) {
     function end() {
         var results = cli.executeOnText(data, file).results;
 
+        //weed out warnings about eslint ignored files that may be piped thru (like from node or bower)
+        results.forEach(function (result) {
+            result.messages = result.messages.filter(function (message) {
+                var isIgnored = !message.fatal && message.message.indexOf('--no-ignore') !== -1;
+                if (isIgnored) {
+                    result.warningCount--;
+                }
+                return !isIgnored;
+            });
+        });
+
         if (results.length && results.some(function (r) { return r.errorCount || r.warningCount; })) {
             error(formatter(results));
         }


### PR DESCRIPTION
Some files may have been set to be ignored via .eslintignore file, but still make there way thru the Browserify pipeline. This includes items like packages from NPM or Bower. 

As a result, you will get a bunch of warnings like:

foo.js
  0:0  warning  File ignored because of your .eslintignore file. Use --no-ignore to override.

✖ 1 problem (0 errors, 1 warning)

(See http://eslint.org/docs/user-guide/configuring#ignored-file-warnings)

This change will weed these errors out since we don't report errors on ignored files.
