### PR TITLE
Add options.nonFatalWarnings to show but not fail on warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,10 +30,10 @@ function lint(file, options) {
             results = eslint.CLIEngine.getErrorResults(results);
         } // filter out warnings
 
-        if (results.length && results.some(options.nonFatalWarnings ? hasErrorCount : hasCount)) {
+        if (results.length && results.some(hasCount)) {
             error(formatter(results));
 
-            if (!options.continuous) {
+            if (!options.continuous && (!options.nonFatalWarnings || results.some(hasErrorCount))) {
                 this.emit('error', 'eslintify: linting error(s) detected.');
             }
         }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ function hasCount(result) {
     return result.errorCount || result.warningCount;
 }
 
+function hasErrorCount(result) {
+    return result.errorCount;
+}
+
 function lint(file, options) {
     options = options || {};
     options.formatter = options.formatter || default_formatter;
@@ -26,7 +30,7 @@ function lint(file, options) {
             results = eslint.CLIEngine.getErrorResults(results);
         } // filter out warnings
 
-        if (results.length && results.some(hasCount)) {
+        if (results.length && results.some(options.nonFatalWarnings ? hasErrorCount : hasCount)) {
             error(formatter(results));
 
             if (!options.continuous) {


### PR DESCRIPTION
don't want to fail a local build if there are warnings, might for example use console.log() for temporary debugging..
